### PR TITLE
Update helpers.php, fix implicit nullable type

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -10,7 +10,7 @@ if (! function_exists('Saade\FilamentExtra\Support\color')) {
 }
 
 if (! function_exists('Saade\FilamentExtra\Support\html')) {
-    function html(string $html = null): ?\Illuminate\Support\HtmlString
+    function html(?string $html = null): ?\Illuminate\Support\HtmlString
     {
         if (! $html) {
             return null;
@@ -21,7 +21,7 @@ if (! function_exists('Saade\FilamentExtra\Support\html')) {
 }
 
 if (! function_exists('Saade\FilamentExtra\Support\md')) {
-    function md(string $string = null): ?\Illuminate\Support\HtmlString
+    function md(?string $string = null): ?\Illuminate\Support\HtmlString
     {
         if (! $string) {
             return null;
@@ -32,7 +32,7 @@ if (! function_exists('Saade\FilamentExtra\Support\md')) {
 }
 
 if (! function_exists('Saade\FilamentExtra\Support\blade')) {
-    function blade(string $string = null, array $data = [], bool $deleteCachedView = false): ?string
+    function blade(?string $string = null, array $data = [], bool $deleteCachedView = false): ?string
     {
         if (! $string) {
             return null;


### PR DESCRIPTION
Hey @saade 

In PHP8.4, I'm getting these warnings, and marking explicitly in the type fixes it.

```
PHP Deprecated:  Saade\FilamentExtra\Support\html(): Implicitly marking parameter $html as nullable is deprecated, the explicit nullable type must be used instead in /Users/patricio/code/mcs/intra24/vendor/saade/filament-extra/src/Support/helpers.php on line 13

Deprecated: Saade\FilamentExtra\Support\html(): Implicitly marking parameter $html as nullable is deprecated, the explicit nullable type must be used instead in /Users/patricio/code/mcs/intra24/vendor/saade/filament-extra/src/Support/helpers.php on line 13
PHP Deprecated:  Saade\FilamentExtra\Support\md(): Implicitly marking parameter $string as nullable is deprecated, the explicit nullable type must be used instead in /Users/patricio/code/mcs/intra24/vendor/saade/filament-extra/src/Support/helpers.php on line 24

Deprecated: Saade\FilamentExtra\Support\md(): Implicitly marking parameter $string as nullable is deprecated, the explicit nullable type must be used instead in /Users/patricio/code/mcs/intra24/vendor/saade/filament-extra/src/Support/helpers.php on line 24
PHP Deprecated:  Saade\FilamentExtra\Support\blade(): Implicitly marking parameter $string as nullable is deprecated, the explicit nullable type must be used instead in /Users/patricio/code/mcs/intra24/vendor/saade/filament-extra/src/Support/helpers.php on line 35

Deprecated: Saade\FilamentExtra\Support\blade(): Implicitly marking parameter $string as nullable is deprecated, the explicit nullable type must be used instead in /Users/patricio/code/mcs/intra24/vendor/saade/filament-extra/src/Support/helpers.php on line 35
```